### PR TITLE
env-var-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ A minimal sample can be found within the [sample](sample/grml.yaml) directory. E
 https://github.com/desertbit/grml/releases
 
 ## Specification
-- Environment variables can be defined in the **env** section. These variables are passed to all run target processes.
+- Environment variables can either be defined in the **env** or **envs** section.  
+  The latter defines paths to dedicated files which use the `key: value` pair syntax.  
+  Variables declared in `envs` files will be evaluated first, ordered by their given sequence  
+  and overwritten by their successor or `env` variable.  
+  These variables are passed to all run target processes.
 - Variables are also accessible with the `${}` selector within **help** messages and **import** statements.
 - Dependencies can be specified within the command's **deps** section.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ https://github.com/desertbit/grml/releases
 ## Specification
 - Environment variables can either be defined in the **env** or **envs** section.  
   The latter defines paths to dedicated files which use the `key: value` pair syntax.  
-  Variables declared in `envs` files will be evaluated first, ordered by their given sequence  
-  and overwritten by their successor or `env` variable.  
+  Variables declared in those files will be evaluated first, ordered by their sequence  
+  and overwritten by their successor or `env` variable if applicable.  
   These variables are passed to all run target processes.
 - Variables are also accessible with the `${}` selector within **help** messages and **import** statements.
 - Dependencies can be specified within the command's **deps** section.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -179,7 +179,10 @@ func (a *app) load() (err error) {
 	a.env["PROJECT"] = a.manifest.Project
 	a.env["ROOT"] = a.rootPath
 	a.env["NUMCPU"] = strconv.Itoa(runtime.NumCPU())
-	a.env = a.manifest.EvalEnv(a.env) // Add values from manifest.
+	a.env, err = a.manifest.EvalEnv(a.env) // Add values from manifest.
+	if err != nil {
+		return
+	}
 
 	// Group all commands to the builtin group (help message).
 	cmds := a.Commands().All()

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -91,15 +91,15 @@ func (m *Manifest) EvalEnv(parentEnv map[string]string) (env map[string]string, 
 		var content []byte
 		content, err = os.ReadFile(ef)
 		if err != nil {
-			err = fmt.Errorf("unable to read env file '%s': %v", ef, err)
+			err = fmt.Errorf("read env file '%s': %v", ef, err)
 			return
 		}
 
-		// Unmarshal environment variable file in an order preserved manner.
+		// Unmarshal environment variable file in an order preserving manner.
 		var ordered yaml.MapSlice
 		err = yaml.Unmarshal(content, &ordered)
 		if err != nil {
-			err = fmt.Errorf("unable to unmarshal env data of file '%s': %v", ef, err)
+			err = fmt.Errorf("unmarshal env file '%s': %v", ef, err)
 			return
 		}
 


### PR DESCRIPTION
Adds the functionality to include environment variables from dedicated files.
This helps projects with a lot of env vars or ignoring specific variables that should not get checked into version control.